### PR TITLE
Added the ability to prefix all bloggy routes if needed

### DIFF
--- a/publishable/config/bloggy.php
+++ b/publishable/config/bloggy.php
@@ -11,7 +11,7 @@ return [
      */
     'database_prefix' => env('BLOGGY_DATABASE_PREFIX', 'bloggy_'),
 
-    /**
+    /*
      * Bloggy routes prefix.
      *
      * Bloggy routes (posts, post types, admin section) will be

--- a/publishable/config/bloggy.php
+++ b/publishable/config/bloggy.php
@@ -11,6 +11,14 @@ return [
      */
     'database_prefix' => env('BLOGGY_DATABASE_PREFIX', 'bloggy_'),
 
+    /**
+     * Bloggy routes prefix.
+     *
+     * Bloggy routes (posts, post types, admin section) will be
+     * offset with this prefix
+     */
+    'routes_prefix' => env('BLOGGY_ROUTES_PREFIX', 'blog'),
+
     /*
      * The user class used as the author of posts created.
      *

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,23 +11,27 @@
 |
 */
 
-Route::group(['prefix' => 'admin', 'namespace' => '\Arukomp\Bloggy\Http\Controllers\Admin', 'middleware' => ['web', 'auth']], function () {
-    Route::get('dashboard', 'DashboardController@index')->name('admin.dashboard');
+$routePrefix = config('bloggy.routes_prefix');
 
-    Route::resource('postTypes', 'PostTypesController', ['as' => 'admin']);
-    Route::resource('trashedPostTypes', 'TrashedPostTypesController', ['as' => 'admin']);
-
-    Route::resource('postType.posts', 'PostsController', ['as' => 'admin', 'only' => ['index', 'create', 'store']]);
-    Route::resource('posts', 'PostsController', ['as' => 'admin', 'only' => ['edit', 'update', 'destroy']]);
-    Route::resource('postType.trashedPosts', 'TrashedPostsController', ['as' => 'admin', 'only' => ['index']]);
-
-    Route::get('postTypes/{id}/restore', 'PostTypesController@restore')->name('admin.postTypes.restore');
-
-    Route::get('posts/{post}/unpublish', 'PostsController@unpublish')->name('admin.posts.unpublish');
-    Route::get('posts/{post}/publish', 'PostsController@publish')->name('admin.posts.publish');
-    Route::put('posts/{post}/restore', 'PostsController@restore')->name('admin.posts.restore');
-});
-
-Route::group(['namespace' => '\Arukomp\Bloggy\Http\Controllers', 'middleware' => ['web']], function () {
-    Route::get('/{postType}/{post}', 'PostsController@show')->name('posts.show');
+Route::group(['prefix' => $routePrefix], function () {
+    Route::group(['prefix' => 'admin', 'namespace' => '\Arukomp\Bloggy\Http\Controllers\Admin', 'middleware' => ['web', 'auth']], function () {
+        Route::get('dashboard', 'DashboardController@index')->name('admin.dashboard');
+    
+        Route::resource('postTypes', 'PostTypesController', ['as' => 'admin']);
+        Route::resource('trashedPostTypes', 'TrashedPostTypesController', ['as' => 'admin']);
+    
+        Route::resource('postType.posts', 'PostsController', ['as' => 'admin', 'only' => ['index', 'create', 'store']]);
+        Route::resource('posts', 'PostsController', ['as' => 'admin', 'only' => ['edit', 'update', 'destroy']]);
+        Route::resource('postType.trashedPosts', 'TrashedPostsController', ['as' => 'admin', 'only' => ['index']]);
+    
+        Route::get('postTypes/{id}/restore', 'PostTypesController@restore')->name('admin.postTypes.restore');
+    
+        Route::get('posts/{post}/unpublish', 'PostsController@unpublish')->name('admin.posts.unpublish');
+        Route::get('posts/{post}/publish', 'PostsController@publish')->name('admin.posts.publish');
+        Route::put('posts/{post}/restore', 'PostsController@restore')->name('admin.posts.restore');
+    });
+    
+    Route::group(['namespace' => '\Arukomp\Bloggy\Http\Controllers', 'middleware' => ['web']], function () {
+        Route::get('/{postType}/{post}', 'PostsController@show')->name('posts.show');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,21 +16,21 @@ $routePrefix = config('bloggy.routes_prefix');
 Route::group(['prefix' => $routePrefix], function () {
     Route::group(['prefix' => 'admin', 'namespace' => '\Arukomp\Bloggy\Http\Controllers\Admin', 'middleware' => ['web', 'auth']], function () {
         Route::get('dashboard', 'DashboardController@index')->name('admin.dashboard');
-    
+
         Route::resource('postTypes', 'PostTypesController', ['as' => 'admin']);
         Route::resource('trashedPostTypes', 'TrashedPostTypesController', ['as' => 'admin']);
-    
+
         Route::resource('postType.posts', 'PostsController', ['as' => 'admin', 'only' => ['index', 'create', 'store']]);
         Route::resource('posts', 'PostsController', ['as' => 'admin', 'only' => ['edit', 'update', 'destroy']]);
         Route::resource('postType.trashedPosts', 'TrashedPostsController', ['as' => 'admin', 'only' => ['index']]);
-    
+
         Route::get('postTypes/{id}/restore', 'PostTypesController@restore')->name('admin.postTypes.restore');
-    
+
         Route::get('posts/{post}/unpublish', 'PostsController@unpublish')->name('admin.posts.unpublish');
         Route::get('posts/{post}/publish', 'PostsController@publish')->name('admin.posts.publish');
         Route::put('posts/{post}/restore', 'PostsController@restore')->name('admin.posts.restore');
     });
-    
+
     Route::group(['namespace' => '\Arukomp\Bloggy\Http\Controllers', 'middleware' => ['web']], function () {
         Route::get('/{postType}/{post}', 'PostsController@show')->name('posts.show');
     });

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -2,11 +2,11 @@
 
 namespace Arukomp\Bloggy\Models;
 
+use Arukomp\Bloggy\Models\Traits\KeepRevisionHistory;
+use Arukomp\Bloggy\Models\Traits\ValidatesModel;
 use Auth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Arukomp\Bloggy\Models\Traits\ValidatesModel;
-use Arukomp\Bloggy\Models\Traits\KeepRevisionHistory;
 
 class Post extends Model
 {

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -2,11 +2,11 @@
 
 namespace Arukomp\Bloggy\Models;
 
-use Arukomp\Bloggy\Models\Traits\KeepRevisionHistory;
-use Arukomp\Bloggy\Models\Traits\ValidatesModel;
 use Auth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Arukomp\Bloggy\Models\Traits\ValidatesModel;
+use Arukomp\Bloggy\Models\Traits\KeepRevisionHistory;
 
 class Post extends Model
 {

--- a/tests/Feature/PostsControllerTest.php
+++ b/tests/Feature/PostsControllerTest.php
@@ -100,7 +100,7 @@ class PostsControllerTest extends TestCase
             'active' => true,
             ])->first();
 
-        $this->get('/'.$post->type->slug.'/hello-world')
+        $this->get(config('bloggy.routes_prefix').'/'.$post->type->slug.'/hello-world')
             ->assertStatus(200)
             ->assertViewIs('bloggy::posts.show')
             ->assertViewHas('post', $post);
@@ -115,8 +115,8 @@ class PostsControllerTest extends TestCase
             'post_type_id' => $anotherPostType->id,
         ]);
 
-        $this->get('/post/'.$post->id)
-            ->assertRedirect('/'.$anotherPostType->slug.'/'.$post->slug);
+        $this->get(config('bloggy.routes_prefix').'/post/'.$post->id)
+            ->assertRedirect(config('bloggy.routes_prefix').'/'.$anotherPostType->slug.'/'.$post->slug);
     }
 
     /** @test */
@@ -124,7 +124,7 @@ class PostsControllerTest extends TestCase
     {
         $post = factory(Post::class)->create(['active' => true])->first();
 
-        $this->get('/'.$post->type->id.'/'.$post->slug)
+        $this->get(config('bloggy.routes_prefix').'/'.$post->type->id.'/'.$post->slug)
             ->assertRedirect($post->url);
     }
 

--- a/tests/Feature/RoutePrefixTest.php
+++ b/tests/Feature/RoutePrefixTest.php
@@ -2,13 +2,11 @@
 
 namespace Arukomp\Bloggy\Tests\Feature;
 
-use Arukomp\Bloggy\Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Arukomp\Bloggy\Models\Post;
 use Arukomp\Bloggy\Tests\Stubs\User;
-use Arukomp\Bloggy\Models\PostType;
+use Arukomp\Bloggy\Tests\TestCase;
 
-class PostsControllerTest extends TestCase
+class RoutePrefixTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
@@ -43,7 +41,7 @@ class PostsControllerTest extends TestCase
         $post = factory(Post::class)->create([]);
 
         $this->assertEquals(
-            config('app.url').'/test_prefix/'.$post->type->slug . '/' . $post->slug,
+            config('app.url').'/test_prefix/'.$post->type->slug.'/'.$post->slug,
             $post->url
         );
 

--- a/tests/Feature/RoutePrefixTest.php
+++ b/tests/Feature/RoutePrefixTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Arukomp\Bloggy\Tests\Feature;
+
+use Arukomp\Bloggy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Arukomp\Bloggy\Models\Post;
+use Arukomp\Bloggy\Tests\Stubs\User;
+use Arukomp\Bloggy\Models\PostType;
+
+class PostsControllerTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('bloggy.routes_prefix', 'test_prefix');
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->actingAs(factory(User::class)->create());
+    }
+
+    /** @test */
+    public function itPrefixesAdminRoutes()
+    {
+        $this->assertEquals(
+            config('app.url').'/test_prefix/admin/dashboard',
+            route('admin.dashboard')
+        );
+
+        $this->assertEquals(
+            config('app.url').'/test_prefix/admin/postTypes',
+            route('admin.postTypes.index')
+        );
+    }
+
+    /** @test */
+    public function itPrefixesPublicRoutes()
+    {
+        $post = factory(Post::class)->create([]);
+
+        $this->assertEquals(
+            config('app.url').'/test_prefix/'.$post->type->slug . '/' . $post->slug,
+            $post->url
+        );
+
+        $this->withoutExceptionHandling()
+            ->get($post->url)
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Added `bloggy.routes_prefix` config option to allow prefixing all Bloggy routes if needed. This includes minimal tests.